### PR TITLE
chore(android): 区分手机端和桌面端权限配置

### DIFF
--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -1,0 +1,20 @@
+{
+  "identifier": "desktop-capability",
+  "platforms": ["linux", "macOS", "windows"],
+  "windows": ["main"],
+  "permissions": [
+    "path:default",
+    "event:default",
+    "window:default",
+    "app:default",
+    "resources:default",
+    "menu:default",
+    "tray:default",
+    "shell:default",
+    "clipboard-manager:allow-write-text",
+    "shell:allow-open",
+    "dialog:allow-open",
+    "file-picker-android:allow-pickFiles",
+    "os:allow-platform"
+  ]
+}

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -1,8 +1,7 @@
 {
-  "identifier": "migrated",
-  "description": "permissions that were migrated from v1",
-  "local": true,
+  "identifier": "mobile-capability",
   "windows": ["main"],
+  "platforms": ["iOS", "android"],
   "permissions": [
     "path:default",
     "event:default",
@@ -11,10 +10,6 @@
     "resources:default",
     "menu:default",
     "tray:default",
-    "shell:default",
-    "clipboard-manager:allow-write-text",
-    "shell:allow-open",
-    "dialog:allow-open",
     "file-picker-android:allow-pickFiles",
     "os:allow-platform"
   ]


### PR DESCRIPTION
手机端和桌面端用到的插件不完全相同，需要分别配置这这个平台的插件的权限。