### PR TITLE
fix: ubuntu 上缺少依赖的问题

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf libwebkit2gtk-4.1-dev
 
       - name: get version with alpha or beta deleted on Windows
         if: matrix.platform == 'windows-latest'


### PR DESCRIPTION
tauri 2 要求 libwebkit2gtk-4.1-dev。